### PR TITLE
Fix CAPI resource status checks for CAPI v1beta2 API

### DIFF
--- a/ocviapy/__init__.py
+++ b/ocviapy/__init__.py
@@ -67,8 +67,21 @@ def traverse_keys(d, keys, default=None):
 def parse_restype(string):
     """
     Given a resource type or its shortcut, return the full resource type name.
+
+    Supports fully-qualified resource types like 'clusters.cluster.x-k8s.io'
+    (i.e. <name>.<apigroup>) to disambiguate when multiple API groups define
+    the same resource name.
     """
     s = string.lower()
+
+    # check for fully-qualified format: <name>.<apigroup>
+    if "." in s:
+        for r in get_api_resources():
+            apigroup_no_version = r["apigroup"].split("/")[0]
+            qualified = f"{r['name']}.{apigroup_no_version}"
+            if s == qualified:
+                return qualified
+
     for r in get_api_resources():
         if s in r["shortnames"] or s == r["name"]:
             return r["name"]

--- a/ocviapy/__init__.py
+++ b/ocviapy/__init__.py
@@ -345,11 +345,12 @@ _CHECKABLE_RESOURCES = (
     "kafkaconnect",
     "cyndipipeline",
     "xjoinpipeline",
-    # CAPI — Cluster API resources for ROSA HCP cluster provisioning
-    "cluster",
+    # CAPI — Cluster API resources for ROSA HCP cluster provisioning (ordered lowest→highest)
+    "rosamachinepool",
+    "rosacluster",
     "rosacontrolplane",
     "machinepool",
-    "rosamachinepool",
+    "cluster",
 )
 
 
@@ -470,15 +471,22 @@ def _check_status_for_restype(restype, json_data):
         )
 
     elif restype in ("cluster", "rosacontrolplane"):
-        ready = _check_status_condition(status, "Ready", "true")
         if restype == "rosacontrolplane":
-            return ready and _check_status_condition(status, "ROSAControlPlaneReady", "true")
-        return ready
+            return _check_status_condition(status, "ROSAControlPlaneReady", "true")
+        return (
+            status.get("phase", "").lower() == "provisioned"
+            and _check_status_condition(status, "Available", "true")
+        )
+
+    elif restype == "rosacluster":
+        return status.get("ready") is True
 
     elif restype in ("machinepool", "rosamachinepool"):
         if restype == "rosamachinepool":
             return _check_status_condition(status, "RosaMachinePoolReady", "true")
-        return _check_status_condition(status, "Ready", "true")
+        # CAPI v1beta2 moved "Ready" to status.deprecated.v1beta1.conditions
+        v1beta1_status = status.get("deprecated", {}).get("v1beta1", {})
+        return _check_status_condition(v1beta1_status, "Ready", "true")
 
 
 class Resource:


### PR DESCRIPTION
## Summary
- **parse_restype**: support fully-qualified resource types like `clusters.cluster.x-k8s.io` (`<name>.<apigroup>`) to disambiguate when multiple API groups define the same resource name
- **cluster**: use `phase=Provisioned` + `Available` condition instead of `Ready` (removed in v1beta2)
- **rosacontrolplane**: check only `ROSAControlPlaneReady` condition (the generic `Ready` condition was unreliable)
- **rosacluster**: add as a new checkable resource type using `status.ready` boolean
- **machinepool**: look for `Ready` condition under `status.deprecated.v1beta1.conditions` where v1beta2 moved it
- **_CHECKABLE_RESOURCES**: reorder to lowest→highest in the ownership chain

## Test plan
- [ ] Deploy a ROSA HCP cluster and verify `ResourceWatcher`/`ResourceWaiter` correctly detect readiness for all CAPI resource types
- [ ] Confirm `rosacluster` is now tracked and reports ready when `status.ready` is `true`
- [ ] Verify `machinepool` readiness detection works with the v1beta2 deprecated conditions path
- [ ] Verify `parse_restype` correctly resolves fully-qualified resource types (e.g. `clusters.cluster.x-k8s.io`) and still works for short names

🤖 Generated with [Claude Code](https://claude.com/claude-code)