### PR TITLE
Fix release workflow trigger to use 'main' branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Publish ocviapy to PyPI
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - '*'
 


### PR DESCRIPTION
## Summary
- The release workflow was configured to trigger on pushes to `master`, but the repo's default branch is `main`
- This meant the workflow never ran on new commits or tag pushes
- Updated the branch trigger from `master` to `main`

## Test plan
- [ ] Verify the release workflow triggers on the next tag push to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)